### PR TITLE
FUL-21835: bump swagger UI version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM nginx:1.11-alpine
+FROM nginx:1-alpine
 MAINTAINER Beekeeper "contact@beekeeper.io"
 
-ENV VERSION_NORM "2.2.2"
+ENV VERSION_NORM "3.18.3"
 
 ENV API_URL "http://petstore.swagger.io/v2/swagger.json"
 ENV API_KEY "**None**"
@@ -14,9 +14,9 @@ ENV ROOT_PATH "/apidocs"
 
 WORKDIR /app
 
-ADD https://github.com/swagger-api/swagger-ui/archive/$VERSION.tar.gz /app
+ADD https://github.com/swagger-api/swagger-ui/archive/$VERSION.tar.gz /app/
 RUN tar -xvf $VERSION.tar.gz && mv $FOLDER swagger-ui
-COPY nginx.conf /etc/nginx 
+COPY nginx.conf /etc/nginx
 
 ADD run.sh run.sh
 

--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,8 @@ set -e
 
 SWAGGER_HTML=swagger-ui/dist/index.html
 
-sed -i "s|http://petstore.swagger.io/v2/swagger.json|$API_URL|g" $SWAGGER_HTML
-sed -i "s|http://example.com/api|$API_URL|g" $SWAGGER_HTML
+sed -i "s|https://petstore.swagger.io/v2/swagger.json|$API_URL|g" $SWAGGER_HTML
+sed -i "s|https://example.com/api|$API_URL|g" $SWAGGER_HTML
 
 exec nginx -g 'daemon off;'
 


### PR DESCRIPTION
This is a docker image of Swagger UI that we serve under `/apidocs` path.

The reason why I'm updating the version is the old Swagger UI version is not correctly handling JSON Reference strings. It should decode `"#/definitions/Comment%20Put` as `Comment Put` property in definitions section but it fails to do so:
![image](https://user-images.githubusercontent.com/9937780/88396795-4ea56380-cdc3-11ea-96e5-dbfa1196f80b.png)
With newer Swagger UI version the problem is fixed:
![image](https://user-images.githubusercontent.com/9937780/88397039-aa6fec80-cdc3-11ea-86f8-cae4a848b1a4.png)
